### PR TITLE
Add `GET /health` health check endpoint

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -31,6 +31,15 @@ const filterObjectsByPartialIataCode = (
   }
 };
 
+app.get('/health', async (req: Request, res: Response): Promise<void> => {
+  res.header('Content-Type', 'application/json');
+  res.header('Cache-Control', 'no-store, no-cache, must-revalidate, private');
+  res.header('Pragma', 'no-cache');
+  res.header('Expires', '0');
+
+  res.status(200).json({ success: true });
+});
+
 app.get('/airports', async (req: Request, res: Response): Promise<void> => {
   res.header('Content-Type', 'application/json');
   res.header('Cache-Control', `public, max-age=${ONE_DAY_IN_SECONDS}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,6 @@ dotenv.config();
 
 const PORT = process.env.PORT;
 
-app.listen(PORT, (): void => console.log(`✈️  Airports API running on port ${PORT}`));
+app.listen(PORT, (): void =>
+  console.log(`✈️  IATA Code Decoder API running on port ${PORT}`),
+);


### PR DESCRIPTION
This adds a new `GET /health` health check endpoint to the app which can be used by Azure App Service (or anyone else, for that matter) to check if the service is up and working.