### PR TITLE
perf: replace O(n) filtering with pre-computed prefix index for O(1) lookups

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -12,7 +12,7 @@ import { randomUUID } from 'node:crypto';
 import { AIRPORTS } from './airports.js';
 import { AIRLINES } from './airlines.js';
 import { AIRCRAFT } from './aircraft.js';
-import { Keyable } from './types.js';
+import { PrefixIndex } from './prefixIndex.js';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   CallToolRequestSchema,
@@ -123,7 +123,7 @@ function createMcpServer(): Server {
     try {
       switch (name) {
         case 'lookup_airport': {
-          const airports = filterObjectsByPartialIataCode(AIRPORTS, query, 3);
+          const airports = airportIndex.lookup(query);
           return {
             content: [
               {
@@ -143,7 +143,7 @@ function createMcpServer(): Server {
         }
 
         case 'lookup_airline': {
-          const airlines = filterObjectsByPartialIataCode(AIRLINES, query, 2);
+          const airlines = airlineIndex.lookup(query);
           return {
             content: [
               {
@@ -163,7 +163,7 @@ function createMcpServer(): Server {
         }
 
         case 'lookup_aircraft': {
-          const aircraft = filterObjectsByPartialIataCode(AIRCRAFT, query, 3);
+          const aircraft = aircraftIndex.lookup(query);
           return {
             content: [
               {
@@ -201,19 +201,10 @@ await app.register(fastifyCors, { origin: '*' });
 // Register compression plugin
 await app.register(fastifyCompress);
 
-const filterObjectsByPartialIataCode = (
-  objects: Keyable[],
-  partialIataCode: string,
-  iataCodeLength: number,
-): Keyable[] => {
-  if (partialIataCode.length > iataCodeLength) {
-    return [];
-  } else {
-    return objects.filter((object) =>
-      object.iataCode.toLowerCase().startsWith(partialIataCode.toLowerCase()),
-    );
-  }
-};
+// Pre-computed prefix indexes for O(1) lookups instead of O(n) filtering
+const airportIndex = new PrefixIndex(AIRPORTS, 3);
+const airlineIndex = new PrefixIndex(AIRLINES, 2);
+const aircraftIndex = new PrefixIndex(AIRCRAFT, 3);
 
 // Query parameter interface
 interface QueryParams {
@@ -296,7 +287,7 @@ app.get<{ Querystring: QueryParams }>(
       return QUERY_MUST_BE_PROVIDED_ERROR;
     } else {
       const query = request.query.query;
-      const airports = filterObjectsByPartialIataCode(AIRPORTS, query, 3);
+      const airports = airportIndex.lookup(query);
       return { data: airports };
     }
   },
@@ -320,7 +311,7 @@ app.get<{ Querystring: QueryParams }>(
       return { data: AIRLINES };
     } else {
       const query = request.query.query;
-      const airlines = filterObjectsByPartialIataCode(AIRLINES, query, 2);
+      const airlines = airlineIndex.lookup(query);
 
       return {
         data: airlines,
@@ -349,7 +340,7 @@ app.get<{ Querystring: QueryParams }>(
       return QUERY_MUST_BE_PROVIDED_ERROR;
     } else {
       const query = request.query.query;
-      const aircraft = filterObjectsByPartialIataCode(AIRCRAFT, query, 3);
+      const aircraft = aircraftIndex.lookup(query);
       return { data: aircraft };
     }
   },

--- a/src/prefixIndex.ts
+++ b/src/prefixIndex.ts
@@ -1,0 +1,37 @@
+import { Keyable } from './types.js';
+
+/**
+ * Pre-computed prefix index for O(1) IATA code lookups instead of O(n) filtering.
+ */
+export class PrefixIndex {
+  private index: Map<string, Keyable[]>;
+  private maxKeyLength: number;
+
+  constructor(objects: Keyable[], maxKeyLength: number) {
+    this.maxKeyLength = maxKeyLength;
+    this.index = new Map();
+
+    for (const obj of objects) {
+      const code = obj.iataCode.toLowerCase();
+      for (let len = 1; len <= Math.min(code.length, this.maxKeyLength); len++) {
+        const prefix = code.substring(0, len);
+        if (!this.index.has(prefix)) {
+          this.index.set(prefix, []);
+        }
+        this.index.get(prefix)!.push(obj);
+      }
+    }
+  }
+
+  lookup(query: string): Keyable[] {
+    const normalized = query.toLowerCase();
+
+    // For over-length queries, use the longest valid prefix for a best-effort match
+    if (normalized.length > this.maxKeyLength) {
+      const truncated = normalized.substring(0, this.maxKeyLength);
+      return this.index.get(truncated) ?? [];
+    }
+
+    return this.index.get(normalized) ?? [];
+  }
+}

--- a/src/prefixIndex.ts
+++ b/src/prefixIndex.ts
@@ -26,10 +26,9 @@ export class PrefixIndex {
   lookup(query: string): Keyable[] {
     const normalized = query.toLowerCase();
 
-    // For over-length queries, use the longest valid prefix for a best-effort match
+    // Queries longer than the max IATA code length can never match
     if (normalized.length > this.maxKeyLength) {
-      const truncated = normalized.substring(0, this.maxKeyLength);
-      return this.index.get(truncated) ?? [];
+      return [];
     }
 
     return this.index.get(normalized) ?? [];


### PR DESCRIPTION
## Summary

Replaces the linear `filterObjectsByPartialIataCode` function with a `PrefixIndex` class that pre-computes a `Map<string, Keyable[]>` of all IATA code prefixes at startup.

### Before
Every API request scanned the full dataset with `Array.filter()` — **O(n)** per query.

### After
A single `Map.get()` call — **O(1)** per query. The index is built once at module load.

### Changes
- New `src/prefixIndex.ts` with the `PrefixIndex` class
- Updated `src/api.ts` to use pre-built indexes for airports, airlines, and aircraft
- Updated MCP tool handlers to use the same indexes