### PR TITLE
⚡ Bolt: optimize IATA code lookups with prefix Maps

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,9 @@
+# Bolt's Performance Journal
+
+## 2025-03-30 - Prefix-based Map for IATA search
+**Learning:** Linear scans ($O(N)$) using `filter` on datasets of ~10,000 items (like the airports list) are a bottleneck for high-frequency search endpoints. Given that IATA codes have a very small, fixed set of possible prefixes (max 3 characters), a prefix-based Map provides a massive speedup with minimal memory overhead.
+**Action:** Always consider pre-indexing small-to-medium static datasets at startup if they are frequently queried by prefix or exact match.
+
+## 2025-03-30 - Case-sensitivity in Map keys
+**Learning:** `Map` keys are case-sensitive. To maintain functional parity with case-insensitive `startsWith` filtering, both the index keys and the incoming query must be normalized (e.g., to lowercase).
+**Action:** Standardize on lowercase for Map keys when building search indexes for user-provided queries.

--- a/src/api.ts
+++ b/src/api.ts
@@ -123,7 +123,7 @@ function createMcpServer(): Server {
     try {
       switch (name) {
         case 'lookup_airport': {
-          const airports = filterObjectsByPartialIataCode(AIRPORTS, query, 3);
+          const airports = AIRPORTS_PREFIX_MAP.get(query.toLowerCase()) || [];
           return {
             content: [
               {
@@ -143,7 +143,7 @@ function createMcpServer(): Server {
         }
 
         case 'lookup_airline': {
-          const airlines = filterObjectsByPartialIataCode(AIRLINES, query, 2);
+          const airlines = AIRLINES_PREFIX_MAP.get(query.toLowerCase()) || [];
           return {
             content: [
               {
@@ -163,7 +163,7 @@ function createMcpServer(): Server {
         }
 
         case 'lookup_aircraft': {
-          const aircraft = filterObjectsByPartialIataCode(AIRCRAFT, query, 3);
+          const aircraft = AIRCRAFT_PREFIX_MAP.get(query.toLowerCase()) || [];
           return {
             content: [
               {
@@ -201,19 +201,30 @@ await app.register(fastifyCors, { origin: '*' });
 // Register compression plugin
 await app.register(fastifyCompress);
 
-const filterObjectsByPartialIataCode = (
-  objects: Keyable[],
-  partialIataCode: string,
-  iataCodeLength: number,
-): Keyable[] => {
-  if (partialIataCode.length > iataCodeLength) {
-    return [];
-  } else {
-    return objects.filter((object) =>
-      object.iataCode.toLowerCase().startsWith(partialIataCode.toLowerCase()),
-    );
+/**
+ * Creates a Map where keys are all possible lowercase prefixes of the IATA codes
+ * and values are arrays of objects that match that prefix.
+ * This allows for O(1) lookup of objects by partial IATA code.
+ */
+const createPrefixMap = (objects: Keyable[]): Map<string, Keyable[]> => {
+  const map = new Map<string, Keyable[]>();
+  for (const obj of objects) {
+    const code = obj.iataCode.toLowerCase();
+    for (let i = 1; i <= code.length; i++) {
+      const prefix = code.substring(0, i);
+      if (!map.has(prefix)) {
+        map.set(prefix, []);
+      }
+      map.get(prefix)!.push(obj);
+    }
   }
+  return map;
 };
+
+// Initialize prefix Maps for fast O(1) lookup
+const AIRPORTS_PREFIX_MAP = createPrefixMap(AIRPORTS);
+const AIRLINES_PREFIX_MAP = createPrefixMap(AIRLINES);
+const AIRCRAFT_PREFIX_MAP = createPrefixMap(AIRCRAFT);
 
 // Query parameter interface
 interface QueryParams {
@@ -296,7 +307,7 @@ app.get<{ Querystring: QueryParams }>(
       return QUERY_MUST_BE_PROVIDED_ERROR;
     } else {
       const query = request.query.query;
-      const airports = filterObjectsByPartialIataCode(AIRPORTS, query, 3);
+      const airports = AIRPORTS_PREFIX_MAP.get(query.toLowerCase()) || [];
       return { data: airports };
     }
   },
@@ -320,7 +331,7 @@ app.get<{ Querystring: QueryParams }>(
       return { data: AIRLINES };
     } else {
       const query = request.query.query;
-      const airlines = filterObjectsByPartialIataCode(AIRLINES, query, 2);
+      const airlines = AIRLINES_PREFIX_MAP.get(query.toLowerCase()) || [];
 
       return {
         data: airlines,
@@ -349,7 +360,7 @@ app.get<{ Querystring: QueryParams }>(
       return QUERY_MUST_BE_PROVIDED_ERROR;
     } else {
       const query = request.query.query;
-      const aircraft = filterObjectsByPartialIataCode(AIRCRAFT, query, 3);
+      const aircraft = AIRCRAFT_PREFIX_MAP.get(query.toLowerCase()) || [];
       return { data: aircraft };
     }
   },


### PR DESCRIPTION
The original search logic iterated through the entire dataset (up to 9,000+ items) for every request, performing a case-insensitive `startsWith` check. While this was fast enough for low traffic, it's inefficient for a search API.

I've introduced a `createPrefixMap` helper that pre-processes the data at startup into Maps where keys are all possible lowercase prefixes of the IATA codes. This allows for near-instant lookups.

Key changes:
- Added `createPrefixMap` helper function to `src/api.ts`.
- Initialized `AIRPORTS_PREFIX_MAP`, `AIRLINES_PREFIX_MAP`, and `AIRCRAFT_PREFIX_MAP` at startup.
- Refactored both REST and MCP handlers to use these Maps.
- Removed the now redundant `filterObjectsByPartialIataCode` function.
- Logged the optimization in Bolt's journal.

---
*PR created automatically by Jules for task [13641998590892968432](https://jules.google.com/task/13641998590892968432) started by @timrogers*