### PR TITLE
Update copyright year in LICENSE.md to 2026 (U2S)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022 Tim Rogers
+Copyright (c) 2026 Tim Rogers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Happy New Year! 🎉

This PR updates the copyright year in LICENSE.md to 2026.

_Created via the GitHub REST API using a user-to-server token from the OAuth device flow._