### PR TITLE
Fix missing timeZone field in airport API responses

### DIFF
--- a/__tests__/api.integration.test.ts
+++ b/__tests__/api.integration.test.ts
@@ -90,6 +90,7 @@ describe('IATA Code Decoder API - Integration Tests', () => {
       expect(airport.iataCode).toBe('LHR');
       expect(airport.name).toBeDefined();
       expect(airport.cityName).toBeDefined();
+      expect(airport.timeZone).toBe('Europe/London');
     });
 
     it('should return airports matching partial query (L)', async () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -301,7 +301,7 @@ const airportSchema = {
     name: { type: 'string' },
     latitude: { type: 'number' },
     longitude: { type: 'number' },
-    time_zone: { type: 'string' },
+    timeZone: { type: 'string' },
     iataCountryCode: { type: 'string' },
     cityName: { type: 'string' },
     city: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface City {
 }
 
 export interface Airport {
-  time_zone: string;
+  timeZone: string;
   name: string;
   longitude: number;
   latitude: number;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Airport responses were missing the timezone field. The cached data stores it as `time_zone`, which the data loader correctly converts to `timeZone`, but the Fastify response schema and `Airport` type still referenced `time_zone`. Fastify's serializer dropped the field because the property names did not match.

## Changes

- Renamed `time_zone` to `timeZone` in the `Airport` type and airport response schema to match the camelCase convention used elsewhere in the API
- Added an integration test asserting that LHR returns `timeZone: "Europe/London"`

## Verification

- `npm run build` passes
- `npm run test` passes (37/37)
- Live API check: `GET /airports?query=LHR` now includes `"timeZone": "Europe/London"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1fd4-7883-7ae0-9ae7-9bedb0fdd16e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1fd4-7883-7ae0-9ae7-9bedb0fdd16e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

